### PR TITLE
Dynamic currency symbol placement

### DIFF
--- a/app/src/main/java/com/eipna/centsation/data/Currency.java
+++ b/app/src/main/java/com/eipna/centsation/data/Currency.java
@@ -1,5 +1,7 @@
 package com.eipna.centsation.data;
 
+import java.text.NumberFormat;
+
 public enum Currency {
     AFGHANI("Afghan Afghani", "AFN", "؋"),
     LEK("Albanian Lek", "ALL", "L"),
@@ -219,5 +221,29 @@ public enum Currency {
             codes[i] = values()[i].CODE;
         }
         return codes;
+    }
+
+    public static String formatAmount(String currencyCode, double amount) {
+        String symbol = getSymbol(currencyCode);
+        String formattedAmount = NumberFormat.getInstance().format(amount);
+
+        String[] suffixCurrencies = {
+                "EUR", "PLN", "CZK", "HUF", "SEK", "NOK", "DKK", "ISK", "TRY", "RON", "BGN", "HRK",
+                "CHF", "RSD", "UAH", "BYN", "MDL", "GEL", "AMD", "AZN", "KZT", "KGS", "UZS", "TMT",
+                "ALL", "BAM", "MKD", "RUB", "LVL", "LTL", "EEK", "SKK", "SIT",
+                "BRL", "ARS", "CLP", "COP", "PEN", "UYU", "BOB", "PYG", "VES",
+                "CNY", "JPY", "KRW", "VND", "THB", "MYR", "SGD", "IDR", "PHP", "LAK", "MMK", "KHR",
+                "ZAR", "EGP", "MAD", "TND", "DZD", "NGN", "GHS", "KES", "TZS", "UGX", "RWF", "ETB",
+                "TRY", "IRR", "IQD", "JOD", "LBP", "SYP", "QAR", "AED", "OMR", "BHD", "KWD", "SAR",
+                "INR", "PKR", "BDT", "LKR", "NPR", "BTN", "AFN", "MZN", "AOA", "XAF", "XOF"
+        };
+
+        for (String suffixCurrency : suffixCurrencies) {
+            if (suffixCurrency.equals(currencyCode)) {
+                return formattedAmount + " " + symbol;
+            }
+        }
+
+        return symbol + formattedAmount;
     }
 }

--- a/app/src/main/java/com/eipna/centsation/ui/adapters/SavingAdapter.java
+++ b/app/src/main/java/com/eipna/centsation/ui/adapters/SavingAdapter.java
@@ -1,7 +1,6 @@
 package com.eipna.centsation.ui.adapters;
 
 import android.content.Context;
-import android.icu.text.NumberFormat;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.style.StrikethroughSpan;
@@ -101,7 +100,6 @@ public class SavingAdapter extends RecyclerView.Adapter<SavingAdapter.ViewHolder
         }
 
         public void bind(Saving currentSaving, PreferenceUtil preferences) {
-            String currencySymbol = Currency.getSymbol(preferences.getCurrency());
             String deadlineFormat = preferences.getDeadlineFormat();
             int percentValue = (int) ((currentSaving.getCurrentSaving() / currentSaving.getGoal()) * 100);
 
@@ -135,8 +133,8 @@ public class SavingAdapter extends RecyclerView.Adapter<SavingAdapter.ViewHolder
 
             percent.setText(String.format("(%s%c)", percentValue, '%'));
             parent.setChecked(currentSaving.getCurrentSaving() >= currentSaving.getGoal());
-            saving.setText(String.format("%s%s", currencySymbol, NumberFormat.getInstance().format(currentSaving.getCurrentSaving())));
-            goal.setText(String.format("%s%s", currencySymbol, NumberFormat.getInstance().format(currentSaving.getGoal())));
+            saving.setText(Currency.formatAmount(preferences.getCurrency(), currentSaving.getCurrentSaving()));
+            goal.setText(Currency.formatAmount(preferences.getCurrency(), currentSaving.getGoal()));
             progress.setProgress(percentValue, true);
         }
     }

--- a/app/src/main/java/com/eipna/centsation/ui/adapters/TransactionAdapter.java
+++ b/app/src/main/java/com/eipna/centsation/ui/adapters/TransactionAdapter.java
@@ -1,7 +1,6 @@
 package com.eipna.centsation.ui.adapters;
 
 import android.content.Context;
-import android.icu.text.NumberFormat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -61,17 +60,17 @@ public class TransactionAdapter extends RecyclerView.Adapter<TransactionAdapter.
         }
 
         public void bind(Transaction currentTransaction, PreferenceUtil preferenceUtil, Context context) {
-            String selectedCurrencySymbol = Currency.getSymbol(preferenceUtil.getCurrency());
+            String selectedCurrencySymbol = preferenceUtil.getCurrency();
 
             type.setText(currentTransaction.getType());
             date.setText(DateUtil.getStringDate(currentTransaction.getDate()));
 
             if (currentTransaction.getType().equals(TransactionType.DEPOSIT.VALUE) || currentTransaction.getType().equals(TransactionType.CREATED.VALUE)) {
                 amount.setTextColor(context.getResources().getColor(R.color.md_theme_secondary, itemView.getContext().getTheme()));
-                amount.setText(String.format("%c%s%s", '+', selectedCurrencySymbol, NumberFormat.getInstance().format(currentTransaction.getAmount())));
+                amount.setText(String.format("%c%s", '+', Currency.formatAmount(selectedCurrencySymbol, currentTransaction.getAmount())));
             } else if (currentTransaction.getType().equals(TransactionType.WITHDRAW.VALUE)) {
                 amount.setTextColor(context.getResources().getColor(R.color.md_theme_error, itemView.getContext().getTheme()));
-                amount.setText(String.format("%c%s%s", '-', selectedCurrencySymbol, NumberFormat.getInstance().format(currentTransaction.getAmount())));
+                amount.setText(String.format("%c%s", '-', Currency.formatAmount(selectedCurrencySymbol, currentTransaction.getAmount())));
             }
         }
     }


### PR DESCRIPTION
Currently, the app displays all currency codes before the value, resulting in "$1", "€1", "CHF1", and so on. While it is considered the proper way to display USD, it is more common to use "1 €" and "1 CHF" for the latter. I introduced a function with a flexible list of currencies that look better when displayed after the value in strings, leaving others display as before.

![image](https://github.com/user-attachments/assets/c302b341-9b78-4e30-a78f-e87e844a5cee)

![image](https://github.com/user-attachments/assets/84c49346-da8f-4cb8-8454-e2ad2fed1ac4)
